### PR TITLE
chore: refer to `docker compose` rather than `docker-compose`

### DIFF
--- a/apps/docs/src/content/docs/self-hosting/docker.md
+++ b/apps/docs/src/content/docs/self-hosting/docker.md
@@ -18,7 +18,7 @@ Then, open the `docker.env` file and fill in the environment variables. You can 
 When you’re done, you can start Vrite with:
 
 ```bash
-docker-compose up
+docker compose up
 
 ```
 


### PR DESCRIPTION
`docker-compose` should not be used anymore: https://docs.docker.com/compose/migrate/