### PR TITLE
fix concurrent startup: BucketAlreadyOwnedByYou

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,17 @@ services:
     image: mongo
     volumes:
       - mongodb:/data/db
-    ports:
-      - 27017:27017
+    # ports:
+    #   - "27017:27017"
 
   minio:
     image: minio/minio
     environment:
       - MINIO_ROOT_USER=user
       - MINIO_ROOT_PASSWORD=password
-    ports:
-      - "9000:9000"
-      - "9001:9001"
+    # ports:
+    #   - "9000:9000"
+    #   - "9001:9001"
     command: server --console-address ":9001" /data
     volumes:
       - minio:/data
@@ -23,13 +23,13 @@ services:
     image: redis
     volumes:
       - redis:/data
-    ports:
-      - "6379:6379"
+    # ports:
+    #   - "6379:6379"
 
   weaviate:
     image: semitechnologies/weaviate:1.21.2
-    ports:
-      - 8080:8080
+    # ports:
+    #   - "8080:8080"
     volumes:
       - weaviate:/var/lib/weaviate
     environment:
@@ -60,6 +60,7 @@ services:
       - mongodb
       - minio
       - redis
+      - api
     environment:
       - PORT=8888
     ports:
@@ -71,6 +72,7 @@ services:
     depends_on:
       - mongodb
       - redis
+      - assets
     environment:
       - PORT=5555
     ports:


### PR DESCRIPTION
When starting for the first time I got this error:
```
/app/index.js:83166
      const exception = new models_0_1.BucketAlreadyOwnedByYou({
                        ^

BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
    at de_BucketAlreadyOwnedByYouRes (/app/index.js:83166:25)
    at de_CreateBucketCommandError (/app/index.js:80322:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /app/index.js:63252:24
    at async /app/index.js:60873:22
    at async /app/index.js:64504:42
    at async /app/index.js:58145:26
    at async /app/index.js:323956:5 {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 409,
    requestId: '1784768FD8139BAD',
    extendedRequestId: 'dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8',
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  Code: 'BucketAlreadyOwnedByYou',
  BucketName: 'vrite-images',
  Resource: '/vrite-images/',
  RequestId: '1784768FD8139BAD',
  HostId: 'dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8'
}

Node.js v18.17.1
```

I think the problem is related to concurrent startup.

By modifying the docker-compose file I was able to solve the problem.

This does not need to be the final fix for solving that problem, I just wanted to make it visible here.

Also I removed all the published ports for the internal services.