### PR TITLE
(docs) Fix self-hosting link in navigation/introduction docs page

### DIFF
--- a/apps/docs/src/content/docs/usage-guide/navigation/navigation.mdx
+++ b/apps/docs/src/content/docs/usage-guide/navigation/navigation.mdx
@@ -3,7 +3,7 @@ slug: "/usage-guide/navigation/introduction"
 title: "Introduction"
 ---
 
-You can get started with Vrite by either [self-hosting](https://app.vrite.io/self-hosting/introduction) it or using the [Vrite Cloud](https://app.vrite.io/auth).
+You can get started with Vrite by either [self-hosting](https://docs.vrite.io/self-hosting/docker) it or using the [Vrite Cloud](https://app.vrite.io/auth).
 
 ## Sign In
 


### PR DESCRIPTION
the current link redirects to the app route

the Docker page is the closest one I found to "self-hosting"